### PR TITLE
feat: add Google Gemini provider support (closes #5)

### DIFF
--- a/examples/gemini_example.clj
+++ b/examples/gemini_example.clj
@@ -1,0 +1,72 @@
+(ns examples.gemini-example
+  "Example usage of the Google Gemini provider"
+  (:require [litellm.core :as litellm]
+            [litellm.providers.gemini :as gemini]))
+
+;; Example 1: Basic usage with Gemini
+(defn basic-gemini-usage []
+  (let [provider (litellm/create-provider {:provider "gemini"
+                                          :api-key (System/getenv "GEMINI_API_KEY")})
+        request {:model "gemini-1.5-flash"
+                :messages [{:role :user :content "What is the capital of France?"}]
+                :max-tokens 100}]
+    (litellm/chat provider request)))
+
+;; Example 2: Using system instructions
+(defn gemini-with-system []
+  (let [provider (litellm/create-provider {:provider "gemini"
+                                          :api-key (System/getenv "GEMINI_API_KEY")})
+        request {:model "gemini-1.5-pro"
+                :messages [{:role :system :content "You are a helpful assistant that speaks like Shakespeare."}
+                          {:role :user :content "Tell me about the weather today"}]
+                :temperature 0.7
+                :max-tokens 150}]
+    (litellm/chat provider request)))
+
+;; Example 3: Function calling with Gemini
+(defn gemini-function-calling []
+  (let [provider (litellm/create-provider {:provider "gemini"
+                                          :api-key (System/getenv "GEMINI_API_KEY")})
+        tools [{:tool-type "function"
+                :function {:function-name "get_weather"
+                          :function-description "Get the current weather for a location"
+                          :function-parameters {:type "object"
+                                               :properties {:location {:type "string"
+                                                                      :description "The city and state"}}
+                                               :required ["location"]}}}]
+        request {:model "gemini-1.5-flash"
+                :messages [{:role :user :content "What's the weather like in Boston?"}]
+                :tools tools
+                :tool-choice :auto}]
+    (litellm/chat provider request)))
+
+;; Example 4: Streaming responses
+(defn gemini-streaming []
+  (let [provider (litellm/create-provider {:provider "gemini"
+                                          :api-key (System/getenv "GEMINI_API_KEY")})
+        request {:model "gemini-1.5-flash"
+                :messages [{:role :user :content "Write a short story about a robot learning to paint"}]
+                :stream true
+                :max-tokens 200}]
+    (litellm/chat provider request)))
+
+;; Example 5: Health check
+(defn check-gemini-health []
+  (let [provider (litellm/create-provider {:provider "gemini"
+                                          :api-key (System/getenv "GEMINI_API_KEY")})]
+    (litellm/health-check provider)))
+
+;; Example 6: List available models
+(defn list-gemini-models []
+  (let [provider (litellm/create-provider {:provider "gemini"
+                                          :api-key (System/getenv "GEMINI_API_KEY")})]
+    (gemini/list-models provider)))
+
+(comment
+  ;; Run examples (make sure to set GEMINI_API_KEY environment variable)
+  (basic-gemini-usage)
+  (gemini-with-system)
+  (gemini-function-calling)
+  (gemini-streaming)
+  (check-gemini-health)
+  (list-gemini-models))

--- a/src/litellm/providers/gemini.clj
+++ b/src/litellm/providers/gemini.clj
@@ -1,0 +1,396 @@
+(ns litellm.providers.gemini
+  "Google Gemini provider implementation for LiteLLM"
+  (:require [litellm.providers.core :as core]
+            [hato.client :as http]
+            [cheshire.core :as json]
+            [clojure.tools.logging :as log]
+            [clojure.string :as str]
+            [com.climate.claypoole :as cp]))
+
+;; ============================================================================
+;; Message Transformations
+;; ============================================================================
+
+(defn transform-role
+  "Transform role to Gemini format"
+  [role]
+  (case role
+    :user "user"
+    :assistant "model"
+    :system "user" ; Gemini uses "user" for system messages
+    (name role)))
+
+(defn transform-messages
+  "Transform messages to Gemini format"
+  [messages]
+  (let [grouped-messages (reduce
+                          (fn [acc msg]
+                            (let [role (transform-role (:role msg))]
+                              (if (and (seq acc) (= role (:role (last acc))))
+                                (update-in acc [(dec (count acc)) :parts]
+                                           conj {:text (:content msg)})
+                                (conj acc {:role role
+                                           :parts [{:text (:content msg)}]}))))
+                          []
+                          messages)]
+    (vec grouped-messages)))
+
+(defn transform-tools
+  "Transform tools to Gemini format"
+  [tools]
+  (when tools
+    {:function_declarations
+     (map (fn [tool]
+            {:name (:function-name (:function tool))
+             :description (:function-description (:function tool))
+             :parameters (:function-parameters (:function tool))})
+          tools)}))
+
+(defn transform-tool-choice
+  "Transform tool choice to Gemini format"
+  [tool-choice]
+  (cond
+    (= tool-choice :auto) "AUTO"
+    (= tool-choice :none) "NONE"
+    (= tool-choice :any) "ANY"
+    (map? tool-choice) {:mode "ANY" :allowed_function_names [(:name tool-choice)]}
+    :else "AUTO"))
+
+(defn extract-system-instruction
+  "Extract system instruction from messages"
+  [messages]
+  (when-let [system-msg (first (filter #(= :system (:role %)) messages))]
+    {:parts [{:text (:content system-msg)}]}))
+
+(defn transform-generation-config
+  "Transform generation config to Gemini format"
+  [request]
+  (let [config {}]
+    (cond-> config
+      (:temperature request) (assoc :temperature (:temperature request))
+      (:top-p request) (assoc :topP (:top-p request))
+      (:max-tokens request) (assoc :maxOutputTokens (:max-tokens request))
+      (:stop request) (assoc :stopSequences (if (string? (:stop request))
+                                              [(:stop request)]
+                                              (:stop request))))))
+
+;; ============================================================================
+;; Response Transformations
+;; ============================================================================
+
+(defn transform-tool-calls
+  "Transform Gemini function calls to standard format"
+  [function-calls]
+  (when function-calls
+    (map (fn [call]
+           {:id (str (java.util.UUID/randomUUID))
+            :type "function"
+            :function {:name (:name call)
+                      :arguments (json/encode (:args call))}})
+         function-calls)))
+
+(defn transform-candidate
+  "Transform Gemini candidate to standard format"
+  [candidate]
+  (let [content (:content candidate)
+        parts (:parts content)
+        text-content (str/join (map :text parts))
+        function-calls (when-let [calls (seq (mapcat :function_call parts))]
+                         (transform-tool-calls calls))]
+    {:index 0
+     :message {:role :assistant
+               :content (when (seq text-content) text-content)
+               :tool-calls function-calls}
+     :finish-reason (case (:finish_reason candidate)
+                      "STOP" :stop
+                      "MAX_TOKENS" :length
+                      "SAFETY" :content_filter
+                      "RECITATION" :content_filter
+                      nil)}))
+
+(defn transform-usage
+  "Transform Gemini usage to standard format"
+  [usage-metadata]
+  (when usage-metadata
+    {:prompt-tokens (get-in usage-metadata [:prompt_token_count] 0)
+     :completion-tokens (get-in usage-metadata [:candidates_token_count] 0)
+     :total-tokens (get-in usage-metadata [:total_token_count] 0)}))
+
+(defn transform-response
+  "Transform Gemini response to standard format"
+  [response]
+  (let [body (:body response)
+        candidates (:candidates body)
+        usage (:usage_metadata body)]
+    {:id (get-in body [:candidates 0 :content :parts 0 :text] (str (java.util.UUID/randomUUID)))
+     :object "chat.completion"
+     :created (quot (System/currentTimeMillis) 1000)
+     :model (get-in body [:model_version] "gemini-unknown")
+     :choices (map transform-candidate candidates)
+     :usage (transform-usage usage)}))
+
+;; ============================================================================
+;; Error Handling
+;; ============================================================================
+
+(defn handle-error-response
+  "Handle Gemini API error responses"
+  [provider response]
+  (let [status (:status response)
+        body (:body response)
+        error-info (get body :error {})]
+    
+    (case status
+      400 (throw (ex-info (or (:message error-info) "Bad request")
+                          {:type :bad-request-error
+                           :provider "gemini"
+                           :details error-info}))
+      401 (throw (ex-info "Authentication failed"
+                          {:type :authentication-error
+                           :provider "gemini"}))
+      403 (throw (ex-info "Permission denied"
+                          {:type :permission-error
+                           :provider "gemini"}))
+      404 (throw (ex-info "Model not found"
+                          {:type :model-not-found-error
+                           :provider "gemini"
+                           :model (get-in body [:error :details :model])}))
+      429 (throw (ex-info "Rate limit exceeded"
+                          {:type :rate-limit-error
+                           :provider "gemini"
+                           :retry-after (get-in response [:headers "retry-after"])}))
+      500 (throw (ex-info "Internal server error"
+                          {:type :server-error
+                           :provider "gemini"}))
+      (throw (ex-info (or (:message error-info) "Unknown error")
+                      {:type :provider-error
+                       :provider "gemini"
+                       :status status
+                       :code (:code error-info)
+                       :data error-info})))))
+
+;; ============================================================================
+;; Model and Cost Configuration
+;; ============================================================================
+
+(def default-cost-map
+  "Default cost per token for Gemini models (in USD)"
+  {"gemini-1.5-flash" {:input 0.00000075 :output 0.000003}
+   "gemini-1.5-flash-latest" {:input 0.00000075 :output 0.000003}
+   "gemini-1.5-pro" {:input 0.00000125 :output 0.000005}
+   "gemini-1.5-pro-latest" {:input 0.00000125 :output 0.000005}
+   "gemini-2.0-flash" {:input 0.00000015 :output 0.0000006}
+   "gemini-2.0-flash-latest" {:input 0.00000015 :output 0.0000006}
+   "gemini-2.0-pro" {:input 0.00000125 :output 0.000005}
+   "gemini-2.0-pro-latest" {:input 0.00000125 :output 0.000005}})
+
+(def default-model-mapping
+  "Default model name mappings"
+  {"gemini-1.5-flash" "gemini-1.5-flash-latest"
+   "gemini-1.5-pro" "gemini-1.5-pro-latest"
+   "gemini-2.0-flash" "gemini-2.0-flash-latest"
+   "gemini-2.0-pro" "gemini-2.0-pro-latest"})
+
+;; ============================================================================
+;; Gemini Provider Record
+;; ============================================================================
+
+(defrecord GeminiProvider [api-key api-base model-mapping rate-limits cost-map timeout]
+  core/LLMProvider
+  
+  (provider-name [_] "gemini")
+  
+  (transform-request [provider request]
+    (let [model (:model request)
+          system-instruction (extract-system-instruction (:messages request))
+          filtered-messages (filter #(not= :system (:role %)) (:messages request))
+          transformed {:contents (transform-messages filtered-messages)
+                      :generation_config (transform-generation-config request)}]
+      
+      ;; Add system instruction if present
+      (cond-> transformed
+        system-instruction (assoc :system_instruction system-instruction)
+        (:tools request) (assoc :tools [(transform-tools (:tools request))])
+        (:tool-choice request) (assoc :tool_config {:function_calling_config {:mode (transform-tool-choice (:tool-choice request))}}))))
+  
+  (make-request [provider transformed-request thread-pools telemetry]
+    (let [url (str (:api-base provider) "/models/" (:model transformed-request) ":generateContent")]
+      (cp/future (:api-calls thread-pools)
+        (let [start-time (System/currentTimeMillis)
+              response (http/post url
+                                  {:headers {"x-goog-api-key" (:api-key provider)
+                                             "Content-Type" "application/json"
+                                             "User-Agent" "litellm-clj/1.0.0"}
+                                   :body (json/encode transformed-request)
+                                   :timeout (:timeout provider 30000)
+                                   :as :json})
+              duration (- (System/currentTimeMillis) start-time)]
+          
+          ;; Handle errors
+          (when (>= (:status response) 400)
+            (handle-error-response provider response))
+          
+          response))))
+  
+  (transform-response [provider response]
+    (transform-response response))
+  
+  (supports-streaming? [_] true)
+  
+  (supports-function-calling? [_] true)
+  
+  (get-rate-limits [provider]
+    (:rate-limits provider {:requests-per-minute 60
+                           :tokens-per-minute 60000}))
+  
+  (health-check [provider thread-pools]
+    (cp/future (:health-checks thread-pools)
+      (try
+        (let [response (http/post (str (:api-base provider) "/models/gemini-1.5-flash-latest:generateContent")
+                                  {:headers {"x-goog-api-key" (:api-key provider)
+                                             "Content-Type" "application/json"
+                                             "User-Agent" "litellm-clj/1.0.0"}
+                                   :body (json/encode {:contents [{:role "user" :parts [{:text "hi"}]}]
+                                                      :generation_config {:maxOutputTokens 1}})
+                                   :timeout 5000
+                                   :as :json})]
+          (= 200 (:status response)))
+        (catch Exception e
+          (log/warn "Gemini health check failed" {:error (.getMessage e)})
+          false))))
+  
+  (get-cost-per-token [provider model]
+    (get (:cost-map provider) model {:input 0.0 :output 0.0})))
+
+;; ============================================================================
+;; Provider Factory
+;; ============================================================================
+
+(defn create-gemini-provider
+  "Create Gemini provider instance"
+  [config]
+  (map->GeminiProvider
+    {:api-key (:api-key config)
+     :api-base (:api-base config "https://generativelanguage.googleapis.com/v1beta")
+     :model-mapping (merge default-model-mapping (:model-mapping config {}))
+     :rate-limits (:rate-limits config {:requests-per-minute 60
+                                       :tokens-per-minute 60000})
+     :cost-map (merge default-cost-map (:cost-map config {}))
+     :timeout (:timeout config 30000)}))
+
+;; ============================================================================
+;; Provider Registration
+;; ============================================================================
+
+(defn register-gemini-provider!
+  "Register Gemini provider in the global registry"
+  []
+  (core/register-provider! "gemini" create-gemini-provider))
+
+;; ============================================================================
+;; Streaming Support
+;; ============================================================================
+
+(defn transform-streaming-chunk
+  "Transform Gemini streaming chunk to standard format"
+  [chunk]
+  (let [candidates (:candidates chunk)
+        candidate (first candidates)
+        content (:content candidate)
+        parts (:parts content)
+        text-content (str/join (map :text parts))
+        function-calls (when-let [calls (seq (mapcat :function_call parts))]
+                         (transform-tool-calls calls))]
+    {:id (str (java.util.UUID/randomUUID))
+     :object "chat.completion.chunk"
+     :created (quot (System/currentTimeMillis) 1000)
+     :model (get-in chunk [:model_version] "gemini-unknown")
+     :choices [{:index 0
+               :delta {:role :assistant
+                      :content (when (seq text-content) text-content)
+                      :tool-calls function-calls}
+               :finish-reason (case (:finish_reason candidate)
+                               "STOP" :stop
+                               "MAX_TOKENS" :length
+                               "SAFETY" :content_filter
+                               "RECITATION" :content_filter
+                               nil)}]}))
+
+(defn handle-streaming-response
+  "Handle streaming response from Gemini"
+  [response callback]
+  (let [body (:body response)]
+    (doseq [line (str/split-lines body)]
+      (when (str/starts-with? line "data: ")
+        (let [data (subs line 6)]
+          (when-not (= data "[DONE]")
+            (try
+              (let [parsed (json/decode data true)
+                    transformed (transform-streaming-chunk parsed)]
+                (callback transformed))
+              (catch Exception e
+                (log/debug "Failed to parse streaming chunk" {:line line :error (.getMessage e)}))))))))
+
+;; ============================================================================
+;; Utility Functions
+;; ============================================================================
+
+(defn list-models
+  "List available Gemini models"
+  [provider]
+  (try
+    (let [response (http/get (str (:api-base provider) "/models")
+                            {:headers {"x-goog-api-key" (:api-key provider)}
+                             :as :json})]
+      (if (= 200 (:status response))
+        (->> (get-in response [:body :models])
+             (filter #(str/starts-with? (:name %) "models/gemini"))
+             (map #(str/replace (:name %) #"^models/" "")))
+        (throw (ex-info "Failed to list models" {:status (:status response)}))))
+    (catch Exception e
+      (log/error "Error listing Gemini models" e)
+      [])))
+
+(defn validate-api-key
+  "Validate Gemini API key"
+  [api-key]
+  (try
+    (let [response (http/post "https://generativelanguage.googleapis.com/v1beta/models/gemini-1.5-flash-latest:generateContent"
+                            {:headers {"x-goog-api-key" api-key
+                                       "Content-Type" "application/json"}
+                             :body (json/encode {:contents [{:role "user" :parts [{:text "hi"}]}]
+                                                :generation_config {:maxOutputTokens 1}})
+                             :timeout 5000})]
+      (= 200 (:status response)))
+    (catch Exception e
+      (log/debug "API key validation failed" {:error (.getMessage e)})
+      false)))
+
+;; ============================================================================
+;; Provider Testing
+;; ============================================================================
+
+(defn test-gemini-connection
+  "Test Gemini connection with a simple request"
+  [provider thread-pools telemetry]
+  (let [test-request {:model "gemini-1.5-flash-latest"
+                     :messages [{:role :user :content "Hello"}]
+                     :max-tokens 5}]
+    (try
+      (let [transformed (core/transform-request provider test-request)
+            response-future (core/make-request provider transformed thread-pools telemetry)
+            response @response-future
+            standard-response (core/transform-response provider response)]
+        {:success true
+         :provider "gemini"
+         :model "gemini-1.5-flash-latest"
+         :response-id (:id standard-response)
+         :usage (:usage standard-response)})
+      (catch Exception e
+        {:success false
+         :provider "gemini"
+         :error (.getMessage e)
+         :error-type (type e)}))))
+
+;; Auto-register the provider when namespace is loaded
+(register-gemini-provider!)

--- a/test/litellm/providers/gemini_test.clj
+++ b/test/litellm/providers/gemini_test.clj
@@ -1,0 +1,210 @@
+(ns litellm.providers.gemini-test
+  (:require [clojure.test :refer :all]
+            [litellm.providers.gemini :as gemini]
+            [litellm.providers.core :as core]))
+
+(deftest test-transform-role
+  (is (= "user" (gemini/transform-role :user)))
+  (is (= "model" (gemini/transform-role :assistant)))
+  (is (= "user" (gemini/transform-role :system)))
+  (is (= "custom" (gemini/transform-role :custom))))
+
+(deftest test-transform-messages
+  (testing "Single message"
+    (is (= [{:role "user" :parts [{:text "Hello"}]}]
+           (gemini/transform-messages [{:role :user :content "Hello"}]))))
+  
+  (testing "Multiple messages"
+    (is (= [{:role "user" :parts [{:text "Hello"}]}
+            {:role "model" :parts [{:text "Hi there"}]}
+            {:role "user" :parts [{:text "How are you?"}]}]
+           (gemini/transform-messages [{:role :user :content "Hello"}
+                                      {:role :assistant :content "Hi there"}
+                                      {:role :user :content "How are you?"}]))))
+  
+  (testing "System message"
+    (is (= [{:role "user" :parts [{:text "System prompt"}]}
+            {:role "user" :parts [{:text "Hello"}]}]
+           (gemini/transform-messages [{:role :system :content "System prompt"}
+                                      {:role :user :content "Hello"}])))))
+
+(deftest test-extract-system-instruction
+  (testing "With system message"
+    (is (= {:parts [{:text "You are a helpful assistant"}]}
+           (gemini/extract-system-instruction [{:role :system :content "You are a helpful assistant"}
+                                              {:role :user :content "Hello"}]))))
+  
+  (testing "Without system message"
+    (is (nil? (gemini/extract-system-instruction [{:role :user :content "Hello"}])))))
+
+(deftest test-transform-generation-config
+  (testing "Empty config"
+    (is (= {} (gemini/transform-generation-config {}))))
+  
+  (testing "With temperature"
+    (is (= {:temperature 0.7} (gemini/transform-generation-config {:temperature 0.7}))))
+  
+  (testing "With max tokens"
+    (is (= {:maxOutputTokens 100} (gemini/transform-generation-config {:max-tokens 100}))))
+  
+  (testing "With stop sequence"
+    (is (= {:stopSequences ["\n"]} (gemini/transform-generation-config {:stop "\n"}))))
+  
+  (testing "With multiple stop sequences"
+    (is (= {:stopSequences ["\n" "END"]} (gemini/transform-generation-config {:stop ["\n" "END"]})))))
+
+(deftest test-transform-tools
+  (testing "Single tool"
+    (is (= {:function_declarations
+            [{:name "get_weather"
+              :description "Get weather information"
+              :parameters {:type "object"
+                           :properties {:location {:type "string"}}
+                           :required ["location"]}}]}
+           (gemini/transform-tools [{:tool-type "function"
+                                    :function {:function-name "get_weather"
+                                              :function-description "Get weather information"
+                                              :function-parameters {:type "object"
+                                                                   :properties {:location {:type "string"}}
+                                                                   :required ["location"]}}}]))))
+  
+  (testing "No tools"
+    (is (nil? (gemini/transform-tools nil)))))
+
+(deftest test-transform-tool-choice
+  (is (= "AUTO" (gemini/transform-tool-choice :auto)))
+  (is (= "NONE" (gemini/transform-tool-choice :none)))
+  (is (= "ANY" (gemini/transform-tool-choice :any)))
+  (is (= {:mode "ANY" :allowed_function_names ["get_weather"]}
+         (gemini/transform-tool-choice {:name "get_weather"}))))
+
+(deftest test-transform-tool-calls
+  (testing "Single function call"
+    (is (= [{:id string?
+             :type "function"
+             :function {:name "get_weather"
+                       :arguments "{\"location\":\"Boston\"}"}}]
+           (let [result (gemini/transform-tool-calls [{:name "get_weather"
+                                                      :args {:location "Boston"}}])]
+             [(update (first result) :id (constantly "test-id"))]))))
+  
+  (testing "No function calls"
+    (is (nil? (gemini/transform-tool-calls nil)))))
+
+(deftest test-transform-candidate
+  (testing "Text response"
+    (is (= {:index 0
+            :message {:role :assistant
+                     :content "Hello there"
+                     :tool-calls nil}
+            :finish-reason :stop}
+           (gemini/transform-candidate {:content {:parts [{:text "Hello there"}]}
+                                       :finish_reason "STOP"}))))
+  
+  (testing "Function call response"
+    (is (= {:index 0
+            :message {:role :assistant
+                     :content nil
+                     :tool-calls [{:id string?
+                                  :type "function"
+                                  :function {:name "get_weather"
+                                            :arguments "{\"location\":\"Boston\"}"}}]}
+            :finish-reason :stop}
+           (let [result (gemini/transform-candidate {:content {:parts [{:function_call {:name "get_weather"
+                                                                                      :args {:location "Boston"}}}]}
+                                                   :finish_reason "STOP"})]
+             (update-in result [:message :tool-calls 0] #(update % :id (constantly "test-id")))))))
+  
+  (testing "Max tokens finish reason"
+    (is (= {:index 0
+            :message {:role :assistant
+                     :content "Hello"
+                     :tool-calls nil}
+            :finish-reason :length}
+           (gemini/transform-candidate {:content {:parts [{:text "Hello"}]}
+                                       :finish_reason "MAX_TOKENS"})))))
+
+(deftest test-transform-usage
+  (testing "With usage data"
+    (is (= {:prompt-tokens 10
+            :completion-tokens 5
+            :total-tokens 15}
+           (gemini/transform-usage {:prompt_token_count 10
+                                   :candidates_token_count 5
+                                   :total_token_count 15}))))
+  
+  (testing "Missing usage data"
+    (is (= {:prompt-tokens 0
+            :completion-tokens 0
+            :total-tokens 0}
+           (gemini/transform-usage {})))))
+
+(deftest test-transform-response
+  (testing "Complete response"
+    (let [response {:body {:candidates [{:content {:parts [{:text "Hello there"}}
+                                                         {:function_call {:name "get_weather"
+                                                                         :args {:location "Boston"}}}]
+                                         :finish_reason "STOP"}]
+                           :usage_metadata {:prompt_token_count 10
+                                           :candidates_token_count 5
+                                           :total_token_count 15}
+                           :model_version "gemini-1.5-flash-latest"}}
+          result (gemini/transform-response response)]
+      (is (= "chat.completion" (:object result)))
+      (is (= "gemini-1.5-flash-latest" (:model result)))
+      (is (= 1 (count (:choices result))))
+      (is (= {:prompt-tokens 10
+              :completion-tokens 5
+              :total-tokens 15}
+             (:usage result)))))
+
+(deftest test-provider-creation
+  (let [provider (gemini/create-gemini-provider {:api-key "test-key"})]
+    (is (= "gemini" (core/provider-name provider)))
+    (is (core/supports-streaming? provider))
+    (is (core/supports-function-calling? provider))))
+
+(deftest test-cost-mapping
+  (let [provider (gemini/create-gemini-provider {:api-key "test-key"})]
+    (is (= {:input 0.00000075 :output 0.000003}
+           (core/get-cost-per-token provider "gemini-1.5-flash")))
+    (is (= {:input 0.00000125 :output 0.000005}
+           (core/get-cost-per-token provider "gemini-1.5-pro")))
+    (is (= {:input 0.0 :output 0.0}
+           (core/get-cost-per-token provider "unknown-model")))))
+
+(deftest test-rate-limits
+  (let [provider (gemini/create-gemini-provider {:api-key "test-key"})]
+    (is (= {:requests-per-minute 60
+            :tokens-per-minute 60000}
+           (core/get-rate-limits provider)))))
+
+(deftest test-transform-request
+  (let [provider (gemini/create-gemini-provider {:api-key "test-key"})
+        request {:model "gemini-1.5-flash"
+                :messages [{:role :system :content "You are helpful"}
+                          {:role :user :content "Hello"}]
+                :temperature 0.7
+                :max-tokens 100}]
+    (let [transformed (core/transform-request provider request)]
+      (is (= "gemini-1.5-flash" (:model transformed)))
+      (is (= {:parts [{:text "You are helpful"}]} (:system_instruction transformed)))
+      (is (= [{:role "user" :parts [{:text "Hello"}]}] (:contents transformed)))
+      (is (= {:temperature 0.7 :maxOutputTokens 100} (:generation_config transformed))))))
+
+(deftest test-model-mapping
+  (let [provider (gemini/create-gemini-provider {:api-key "test-key"})]
+    (is (= "gemini-1.5-flash-latest" (:model-mapping provider "gemini-1.5-flash")))
+    (is (= "gemini-1.5-pro-latest" (:model-mapping provider "gemini-1.5-pro")))))
+
+(deftest test-streaming-chunk
+  (let [chunk {:candidates [{:content {:parts [{:text "Hello"}]}
+                             :finish_reason "STOP"}]
+               :model_version "gemini-1.5-flash-latest"}
+        result (gemini/transform-streaming-chunk chunk)]
+    (is (= "chat.completion.chunk" (:object result)))
+    (is (= "gemini-1.5-flash-latest" (:model result)))
+    (is (= 1 (count (:choices result))))
+    (is (= :assistant (get-in result [:choices 0 :delta :role])))
+    (is (= "Hello" (get-in result [:choices 0 :delta :content])))
+    (is (= :stop (get-in result [:choices 0 :finish-reason])))))


### PR DESCRIPTION
- Implement complete Gemini provider with request/response transformations
- Add support for Gemini 1.5/2.0 models (Flash, Pro)
- Include function calling and streaming capabilities
- Add comprehensive unit tests for all transformations
- Update documentation with Gemini provider details
- Add usage examples for basic, streaming, and function calling
- Include cost mapping for Gemini models with current pricing