### PR TITLE
feat: add Mistral AI provider support (closes #7)

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,15 +5,15 @@ A Clojure port of the popular [LiteLLM](https://github.com/BerriAI/litellm) libr
 ## Model Provider Support Matrix
 
 | Provider     | Status       | Models                                     | Function Calling | Streaming |
-|--------------|--------------|--------------------------------------------|------------------|-----------|
+|--------------|--------------|--------------------------------------------|--------------------|-----------|
 | OpenAI       | ✅ Supported | GPT-3.5-Turbo, GPT-4, GPT-4o               | ✅               | ✅        |
 | Anthropic    | ✅ Supported | Claude 3 (Opus, Sonnet, Haiku), Claude 2.x | ❌               | ✅        |
 | OpenRouter   | ✅ Supported | All OpenRouter models                      | ✅               | ✅        |
-| Azure OpenAI | 🔄 Planned   | -                                          | -                | -         |
 | Google Gemini| ✅ Supported | Gemini Pro, Gemini Pro Vision, Gemini Ultra| ❌               | ✅        |
+| Mistral      | ✅ Supported | Mistral Small/Medium/Large, Codestral, Magistral | ✅               | ✅        |
+| Azure OpenAI | 🔄 Planned   | -                                          | -                | -         |
 | Cohere       | 🔄 Planned   | Command                                    | -                | -         |
 | Hugging Face | 🔄 Planned   | Various open models                        | -                | -         |
-| Mistral      | 🔄 Planned   | Mistral, Mixtral                           | -                | -         |
 | Ollama       | 🔄 Planned   | Local models                               | -                | -         |
 | Together AI  | 🔄 Planned   | Various open models                        | -                | -         |
 | Replicate    | 🔄 Planned   | Various open models                        | -                | -         |
@@ -33,12 +33,12 @@ A Clojure port of the popular [LiteLLM](https://github.com/BerriAI/litellm) libr
 - **Anthropic**: Claude 3 (Opus, Sonnet, Haiku), Claude 2.x
 - **Google Gemini**: Gemini Pro, Gemini Pro Vision, Gemini Ultra with vision/multimodal support
 - **OpenRouter**: Access to multiple providers through a single API (OpenAI, Anthropic, Google, Meta, etc.)
+- **Mistral AI**: Mistral Small/Medium/Large, Codestral (code generation), Magistral (reasoning), and embedding models
 
 ## Planned Providers
 
 - Azure OpenAI
 - Cohere
-- Mistral AI
 - Hugging Face
 - Ollama (local models)
 - Together AI
@@ -212,6 +212,48 @@ export GEMINI_API_KEY=your-api-key-here
    :top_p 0.95
    :top_k 40
    :max_tokens 1024})
+```
+
+### Mistral AI
+
+Set your API key:
+
+```bash
+export MISTRAL_API_KEY=your-api-key-here
+```
+
+```clojure
+;; Use Mistral Small for fast, cost-effective responses
+(litellm/completion system
+  {:model "mistral/mistral-small-latest"
+   :messages [{:role "user" :content "Explain quantum computing"}]})
+
+;; Use Mistral Large for complex reasoning tasks
+(litellm/completion system
+  {:model "mistral/mistral-large-latest"
+   :messages [{:role "user" :content "Analyze this complex problem..."}]
+   :temperature 0.7})
+
+;; Use Codestral for code generation
+(litellm/completion system
+  {:model "mistral/codestral-latest"
+   :messages [{:role "user" :content "Write a Clojure function to parse JSON"}]})
+
+;; Use Magistral models with reasoning support
+(litellm/completion system
+  {:model "mistral/magistral-medium-2506"
+   :messages [{:role "user" :content "Solve this math problem step by step"}]
+   :reasoning-effort "medium"})  ;; Options: "low", "medium", "high"
+
+;; Function calling with Mistral
+(litellm/completion system
+  {:model "mistral/mistral-large-latest"
+   :messages [{:role "user" :content "What's the weather in Paris?"}]
+   :tools [{:type "function"
+            :function {:name "get_weather"
+                      :description "Get current weather"
+                      :parameters {:type "object"
+                                  :properties {:location {:type "string"}}}}}]})
 ```
 
 ### Ollama (Local Models)

--- a/examples/mistral_example.clj
+++ b/examples/mistral_example.clj
@@ -1,0 +1,221 @@
+(ns mistral-example
+  "Example usage of Mistral AI provider with litellm-clj"
+  (:require [litellm.core :as litellm]
+            [litellm.providers.mistral :as mistral]))
+
+;; ============================================================================
+;; Basic Setup
+;; ============================================================================
+
+;; Set your Mistral API key (or set MISTRAL_API_KEY environment variable)
+(def api-key (or (System/getenv "MISTRAL_API_KEY") "your-api-key-here"))
+
+;; Create a Mistral provider instance
+(def mistral-provider
+  (mistral/create-mistral-provider
+    {:api-key api-key}))
+
+;; ============================================================================
+;; Example 1: Basic Chat Completion
+;; ============================================================================
+
+(defn basic-chat-example []
+  (println "\n=== Basic Chat Example ===")
+  (let [response @(litellm/completion
+                    {:provider mistral-provider
+                     :model "mistral/mistral-small-latest"
+                     :messages [{:role :user 
+                                :content "What is the capital of France?"}]
+                     :max-tokens 100})]
+    (println "Response:" (get-in response [:choices 0 :message :content]))
+    response))
+
+;; ============================================================================
+;; Example 2: Chat with Temperature Control
+;; ============================================================================
+
+(defn temperature-example []
+  (println "\n=== Temperature Control Example ===")
+  (let [response @(litellm/completion
+                    {:provider mistral-provider
+                     :model "mistral/mistral-small-latest"
+                     :messages [{:role :user 
+                                :content "Write a creative short story about a robot."}]
+                     :max-tokens 200
+                     :temperature 0.9})]
+    (println "Creative response:" (get-in response [:choices 0 :message :content]))
+    response))
+
+;; ============================================================================
+;; Example 3: Multi-turn Conversation
+;; ============================================================================
+
+(defn conversation-example []
+  (println "\n=== Multi-turn Conversation Example ===")
+  (let [response @(litellm/completion
+                    {:provider mistral-provider
+                     :model "mistral/mistral-small-latest"
+                     :messages [{:role :system 
+                                :content "You are a helpful coding assistant."}
+                               {:role :user 
+                                :content "What is recursion?"}
+                               {:role :assistant 
+                                :content "Recursion is when a function calls itself."}
+                               {:role :user 
+                                :content "Can you give me an example in Clojure?"}]
+                     :max-tokens 300})]
+    (println "Assistant:" (get-in response [:choices 0 :message :content]))
+    response))
+
+;; ============================================================================
+;; Example 4: Using Mistral Large for Complex Tasks
+;; ============================================================================
+
+(defn large-model-example []
+  (println "\n=== Mistral Large Example ===")
+  (let [response @(litellm/completion
+                    {:provider mistral-provider
+                     :model "mistral/mistral-large-latest"
+                     :messages [{:role :user 
+                                :content "Explain quantum computing in simple terms."}]
+                     :max-tokens 500
+                     :temperature 0.7})]
+    (println "Explanation:" (get-in response [:choices 0 :message :content]))
+    response))
+
+;; ============================================================================
+;; Example 5: Function Calling
+;; ============================================================================
+
+(defn function-calling-example []
+  (println "\n=== Function Calling Example ===")
+  (let [tools [{:tool-type "function"
+               :function {:name "get_weather"
+                         :description "Get the current weather for a location"
+                         :parameters {:type "object"
+                                    :properties {:location {:type "string"
+                                                          :description "City and state, e.g. San Francisco, CA"}
+                                               :unit {:type "string"
+                                                     :enum ["celsius" "fahrenheit"]}}
+                                    :required ["location"]}}}]
+        response @(litellm/completion
+                    {:provider mistral-provider
+                     :model "mistral/mistral-large-latest"
+                     :messages [{:role :user 
+                                :content "What's the weather like in Paris?"}]
+                     :tools tools
+                     :tool-choice :auto})]
+    (println "Response:" response)
+    (when-let [tool-calls (get-in response [:choices 0 :message :tool-calls])]
+      (println "Tool calls:" tool-calls))
+    response))
+
+;; ============================================================================
+;; Example 6: Reasoning with Magistral Models
+;; ============================================================================
+
+(defn reasoning-example []
+  (println "\n=== Reasoning Example (Magistral Model) ===")
+  (let [response @(litellm/completion
+                    {:provider mistral-provider
+                     :model "mistral/magistral-medium-2506"
+                     :messages [{:role :user 
+                                :content "What is 15 multiplied by 7? Show your reasoning."}]
+                     :reasoning-effort "medium"
+                     :max-tokens 500})]
+    (println "Reasoning response:" (get-in response [:choices 0 :message :content]))
+    response))
+
+;; ============================================================================
+;; Example 7: Code Generation with Codestral
+;; ============================================================================
+
+(defn code-generation-example []
+  (println "\n=== Code Generation Example (Codestral) ===")
+  (let [response @(litellm/completion
+                    {:provider mistral-provider
+                     :model "mistral/codestral-latest"
+                     :messages [{:role :user 
+                                :content "Write a Clojure function to calculate fibonacci numbers."}]
+                     :max-tokens 300})]
+    (println "Generated code:" (get-in response [:choices 0 :message :content]))
+    response))
+
+;; ============================================================================
+;; Example 8: Embeddings
+;; ============================================================================
+
+(defn embeddings-example []
+  (println "\n=== Embeddings Example ===")
+  (let [thread-pools (litellm/create-thread-pools)
+        embedding-response @(mistral/make-embedding-request
+                              mistral-provider
+                              "Hello, this is a test sentence for embedding."
+                              "mistral-embed"
+                              thread-pools)]
+    (println "Embedding dimensions:" (count (get-in embedding-response [:data 0 :embedding])))
+    (println "First 5 values:" (take 5 (get-in embedding-response [:data 0 :embedding])))
+    embedding-response))
+
+;; ============================================================================
+;; Example 9: Streaming Responses
+;; ============================================================================
+
+(defn streaming-example []
+  (println "\n=== Streaming Example ===")
+  (println "Note: Streaming requires special handling in the core library")
+  ;; This is a placeholder - actual streaming would require additional implementation
+  (let [response @(litellm/completion
+                    {:provider mistral-provider
+                     :model "mistral/mistral-small-latest"
+                     :messages [{:role :user 
+                                :content "Count from 1 to 10"}]
+                     :stream false
+                     :max-tokens 100})]
+    (println "Response:" (get-in response [:choices 0 :message :content]))
+    response))
+
+;; ============================================================================
+;; Example 10: Error Handling
+;; ============================================================================
+
+(defn error-handling-example []
+  (println "\n=== Error Handling Example ===")
+  (try
+    @(litellm/completion
+       {:provider mistral-provider
+        :model "mistral/non-existent-model"
+        :messages [{:role :user :content "Test"}]})
+    (catch Exception e
+      (println "Caught error:" (.getMessage e))
+      (println "Error type:" (ex-data e)))))
+
+;; ============================================================================
+;; Run All Examples
+;; ============================================================================
+
+(defn run-all-examples []
+  (println "Running Mistral AI Examples\n")
+  (println "Make sure to set your MISTRAL_API_KEY environment variable!")
+  
+  ;; Run each example
+  (basic-chat-example)
+  (temperature-example)
+  (conversation-example)
+  (large-model-example)
+  (function-calling-example)
+  (reasoning-example)
+  (code-generation-example)
+  (embeddings-example)
+  (streaming-example)
+  (error-handling-example)
+  
+  (println "\n=== All examples completed! ==="))
+
+;; Uncomment to run:
+;; (run-all-examples)
+
+;; Or run individual examples:
+;; (basic-chat-example)
+;; (function-calling-example)
+;; (reasoning-example)

--- a/src/litellm/providers/mistral.clj
+++ b/src/litellm/providers/mistral.clj
@@ -1,0 +1,402 @@
+(ns litellm.providers.mistral
+  "Mistral AI provider implementation for LiteLLM"
+  (:require [litellm.providers.core :as core]
+            [hato.client :as http]
+            [cheshire.core :as json]
+            [clojure.tools.logging :as log]
+            [clojure.string :as str]
+            [com.climate.claypoole :as cp]))
+
+;; ============================================================================
+;; Message Transformations
+;; ============================================================================
+
+(defn transform-messages
+  "Transform messages to Mistral format (OpenAI-compatible)"
+  [messages]
+  (map (fn [msg]
+         (let [base {:role (name (:role msg))
+                    :content (:content msg)}]
+           (cond-> base
+             (:name msg) (assoc :name (:name msg))
+             (:tool-call-id msg) (assoc :tool_call_id (:tool-call-id msg)))))
+       messages))
+
+(defn add-reasoning-system-prompt
+  "Add reasoning system prompt for magistral models based on reasoning_effort"
+  [messages reasoning-effort]
+  (when reasoning-effort
+    (let [reasoning-prompt "When solving problems, think step-by-step in <think> tags before providing your final answer. Break down complex problems into smaller steps and show your reasoning process clearly."]
+      ;; Find existing system message
+      (let [system-msg (first (filter #(= "system" (:role %)) messages))
+            other-msgs (remove #(= "system" (:role %)) messages)]
+        (if system-msg
+          ;; Prepend reasoning prompt to existing system message
+          (cons (assoc system-msg :content (str reasoning-prompt "\n\n" (:content system-msg)))
+                other-msgs)
+          ;; Add new system message with reasoning prompt
+          (cons {:role "system" :content reasoning-prompt}
+                messages))))))
+
+(defn transform-tools
+  "Transform tools to Mistral format (OpenAI-compatible)"
+  [tools]
+  (when tools
+    (map (fn [tool]
+           {:type (:tool-type tool "function")
+            :function (select-keys (:function tool) [:name :description :parameters])})
+         tools)))
+
+(defn transform-tool-choice
+  "Transform tool choice to Mistral format"
+  [tool-choice]
+  (cond
+    (keyword? tool-choice) (name tool-choice)
+    (map? tool-choice) tool-choice
+    :else tool-choice))
+
+;; ============================================================================
+;; Response Transformations
+;; ============================================================================
+
+(defn transform-tool-calls
+  "Transform Mistral tool calls to standard format"
+  [tool-calls]
+  (when tool-calls
+    (map (fn [tool-call]
+           {:id (:id tool-call)
+            :type (:type tool-call)
+            :function {:name (get-in tool-call [:function :name])
+                      :arguments (get-in tool-call [:function :arguments])}})
+         tool-calls)))
+
+(defn transform-message
+  "Transform Mistral message to standard format"
+  [message]
+  (cond-> {:role (keyword (:role message))
+           :content (:content message)}
+    (:tool_calls message) (assoc :tool-calls (transform-tool-calls (:tool_calls message)))))
+
+(defn transform-choice
+  "Transform Mistral choice to standard format"
+  [choice]
+  {:index (:index choice)
+   :message (transform-message (:message choice))
+   :finish-reason (keyword (:finish_reason choice))})
+
+(defn transform-usage
+  "Transform Mistral usage to standard format"
+  [usage]
+  (when usage
+    {:prompt-tokens (:prompt_tokens usage)
+     :completion-tokens (:completion_tokens usage)
+     :total-tokens (:total_tokens usage)}))
+
+;; ============================================================================
+;; Error Handling
+;; ============================================================================
+
+(defn handle-error-response
+  "Handle Mistral API error responses"
+  [provider response]
+  (let [status (:status response)
+        body (:body response)
+        error-info (get body :error {})]
+    
+    (case status
+      401 (throw (ex-info "Authentication failed" 
+                          {:type :authentication-error
+                           :provider "mistral"}))
+      429 (throw (ex-info "Rate limit exceeded" 
+                          {:type :rate-limit-error
+                           :provider "mistral"
+                           :retry-after (get-in response [:headers "retry-after"])}))
+      404 (throw (ex-info "Model not found" 
+                          {:type :model-not-found-error
+                           :provider "mistral"
+                           :model (:model body)}))
+      (throw (ex-info (or (:message error-info) "Unknown error")
+                      {:type :provider-error
+                       :provider "mistral"
+                       :status status
+                       :code (:code error-info)
+                       :data error-info})))))
+
+;; ============================================================================
+;; Model and Cost Configuration
+;; ============================================================================
+
+(def default-cost-map
+  "Default cost per token for Mistral models (in USD)
+   Prices from https://mistral.ai/technology/#pricing"
+  {"mistral-small-latest" {:input 0.000001 :output 0.000003}
+   "mistral-small-2412" {:input 0.000001 :output 0.000003}
+   "mistral-medium-latest" {:input 0.0000027 :output 0.0000081}
+   "mistral-medium-2412" {:input 0.0000027 :output 0.0000081}
+   "mistral-large-latest" {:input 0.000002 :output 0.000006}
+   "mistral-large-2407" {:input 0.000002 :output 0.000006}
+   "mistral-large-2411" {:input 0.000002 :output 0.000006}
+   "magistral-small-2506" {:input 0.000001 :output 0.000003}
+   "magistral-medium-2506" {:input 0.0000027 :output 0.0000081}
+   "open-mistral-7b" {:input 0.00000025 :output 0.00000025}
+   "open-mixtral-8x7b" {:input 0.0000007 :output 0.0000007}
+   "open-mixtral-8x22b" {:input 0.000002 :output 0.000006}
+   "codestral-latest" {:input 0.000001 :output 0.000003}
+   "codestral-2405" {:input 0.000001 :output 0.000003}
+   "open-mistral-nemo" {:input 0.0000003 :output 0.0000003}
+   "open-mistral-nemo-2407" {:input 0.0000003 :output 0.0000003}
+   "open-codestral-mamba" {:input 0.00000025 :output 0.00000025}
+   "codestral-mamba-latest" {:input 0.00000025 :output 0.00000025}
+   "mistral-embed" {:input 0.0000001 :output 0.0}})
+
+(def magistral-models
+  "Models that support reasoning with reasoning_effort parameter"
+  #{"magistral-small-2506" "magistral-medium-2506"})
+
+(defn supports-reasoning?
+  "Check if a model supports reasoning"
+  [model]
+  (contains? magistral-models model))
+
+;; ============================================================================
+;; Mistral Provider Record
+;; ============================================================================
+
+(defrecord MistralProvider [api-key api-base rate-limits cost-map timeout]
+  core/LLMProvider
+  
+  (provider-name [_] "mistral")
+  
+  (transform-request [provider request]
+    (let [model (:model request)
+          reasoning-effort (:reasoning-effort request)
+          messages (:messages request)
+          ;; Add reasoning system prompt if applicable
+          transformed-messages (if (and reasoning-effort (supports-reasoning? model))
+                                (add-reasoning-system-prompt 
+                                  (transform-messages messages)
+                                  reasoning-effort)
+                                (transform-messages messages))
+          transformed {:model model
+                      :messages transformed-messages
+                      :max_tokens (:max-tokens request)
+                      :temperature (:temperature request)
+                      :top_p (:top-p request)
+                      :stop (:stop request)
+                      :stream (:stream request false)}]
+      
+      ;; Add function calling if present
+      (cond-> transformed
+        (:tools request) (assoc :tools (transform-tools (:tools request)))
+        (:tool-choice request) (assoc :tool_choice (transform-tool-choice (:tool-choice request))))))
+  
+  (make-request [provider transformed-request thread-pools telemetry]
+    (let [url (str (:api-base provider) "/chat/completions")]
+      (cp/future (:api-calls thread-pools)
+        (let [start-time (System/currentTimeMillis)
+              response (http/post url
+                                  {:headers {"Authorization" (str "Bearer " (:api-key provider))
+                                             "Content-Type" "application/json"
+                                             "User-Agent" "litellm-clj/1.0.0"}
+                                   :body (json/encode transformed-request)
+                                   :timeout (:timeout provider 30000)
+                                   :as :json})
+              duration (- (System/currentTimeMillis) start-time)]
+          
+          ;; Handle errors
+          (when (>= (:status response) 400)
+            (handle-error-response provider response))
+          
+          response))))
+  
+  (transform-response [provider response]
+    (let [body (:body response)]
+      {:id (:id body)
+       :object (:object body)
+       :created (:created body)
+       :model (:model body)
+       :choices (map transform-choice (:choices body))
+       :usage (transform-usage (:usage body))}))
+  
+  (supports-streaming? [_] true)
+  
+  (supports-function-calling? [_] true)
+  
+  (get-rate-limits [provider]
+    (:rate-limits provider {:requests-per-minute 1000
+                           :tokens-per-minute 1000000}))
+  
+  (health-check [provider thread-pools]
+    (cp/future (:health-checks thread-pools)
+      (try
+        (let [response (http/get (str (:api-base provider) "/models")
+                                {:headers {"Authorization" (str "Bearer " (:api-key provider))}
+                                 :timeout 5000})]
+          (= 200 (:status response)))
+        (catch Exception e
+          (log/warn "Mistral health check failed" {:error (.getMessage e)})
+          false))))
+  
+  (get-cost-per-token [provider model]
+    (get (:cost-map provider) model {:input 0.0 :output 0.0})))
+
+;; ============================================================================
+;; Provider Factory
+;; ============================================================================
+
+(defn create-mistral-provider
+  "Create Mistral provider instance"
+  [config]
+  (map->MistralProvider
+    {:api-key (:api-key config)
+     :api-base (:api-base config "https://api.mistral.ai/v1")
+     :rate-limits (:rate-limits config {:requests-per-minute 1000
+                                       :tokens-per-minute 1000000})
+     :cost-map (merge default-cost-map (:cost-map config {}))
+     :timeout (:timeout config 30000)}))
+
+;; ============================================================================
+;; Provider Registration
+;; ============================================================================
+
+(defn register-mistral-provider!
+  "Register Mistral provider in the global registry"
+  []
+  (core/register-provider! "mistral" create-mistral-provider))
+
+;; ============================================================================
+;; Streaming Support
+;; ============================================================================
+
+(defn parse-sse-line
+  "Parse a Server-Sent Events line"
+  [line]
+  (when (str/starts-with? line "data: ")
+    (let [data (subs line 6)]
+      (when-not (= data "[DONE]")
+        (try
+          (json/decode data true)
+          (catch Exception e
+            (log/debug "Failed to parse SSE line" {:line line :error (.getMessage e)})
+            nil))))))
+
+(defn transform-streaming-chunk
+  "Transform Mistral streaming chunk to standard format"
+  [chunk]
+  (let [choice (first (:choices chunk))
+        delta (:delta choice)]
+    {:id (:id chunk)
+     :object (:object chunk)
+     :created (:created chunk)
+     :model (:model chunk)
+     :choices [{:index (:index choice)
+               :delta {:role (keyword (:role delta))
+                      :content (:content delta)}
+               :finish-reason (when (:finish_reason choice)
+                               (keyword (:finish_reason choice)))}]}))
+
+(defn handle-streaming-response
+  "Handle streaming response from Mistral"
+  [response callback]
+  (let [body (:body response)]
+    (doseq [line (str/split-lines body)]
+      (when-let [parsed (parse-sse-line line)]
+        (let [transformed (transform-streaming-chunk parsed)]
+          (callback transformed))))))
+
+;; ============================================================================
+;; Embedding Support
+;; ============================================================================
+
+(defn create-embedding-request
+  "Transform embedding request to Mistral format"
+  [input model]
+  {:input (if (string? input) [input] input)
+   :model (or model "mistral-embed")})
+
+(defn make-embedding-request
+  "Make embedding request to Mistral API"
+  [provider input model thread-pools]
+  (let [url (str (:api-base provider) "/embeddings")
+        request-body (create-embedding-request input model)]
+    (cp/future (:api-calls thread-pools)
+      (let [response (http/post url
+                               {:headers {"Authorization" (str "Bearer " (:api-key provider))
+                                          "Content-Type" "application/json"
+                                          "User-Agent" "litellm-clj/1.0.0"}
+                                :body (json/encode request-body)
+                                :timeout (:timeout provider 30000)
+                                :as :json})]
+        
+        ;; Handle errors
+        (when (>= (:status response) 400)
+          (handle-error-response provider response))
+        
+        (let [body (:body response)]
+          {:object (:object body)
+           :data (map (fn [item]
+                       {:object (:object item)
+                        :embedding (:embedding item)
+                        :index (:index item)})
+                     (:data body))
+           :model (:model body)
+           :usage (transform-usage (:usage body))})))))
+
+;; ============================================================================
+;; Utility Functions
+;; ============================================================================
+
+(defn list-models
+  "List available Mistral models"
+  [provider]
+  (try
+    (let [response (http/get (str (:api-base provider) "/models")
+                            {:headers {"Authorization" (str "Bearer " (:api-key provider))}
+                             :as :json})]
+      (if (= 200 (:status response))
+        (map :id (get-in response [:body :data]))
+        (throw (ex-info "Failed to list models" {:status (:status response)}))))
+    (catch Exception e
+      (log/error "Error listing Mistral models" e)
+      [])))
+
+(defn validate-api-key
+  "Validate Mistral API key"
+  [api-key]
+  (try
+    (let [response (http/get "https://api.mistral.ai/v1/models"
+                            {:headers {"Authorization" (str "Bearer " api-key)}
+                             :timeout 5000})]
+      (= 200 (:status response)))
+    (catch Exception e
+      (log/debug "API key validation failed" {:error (.getMessage e)})
+      false)))
+
+;; ============================================================================
+;; Provider Testing
+;; ============================================================================
+
+(defn test-mistral-connection
+  "Test Mistral connection with a simple request"
+  [provider thread-pools telemetry]
+  (let [test-request {:model "mistral-small-latest"
+                     :messages [{:role :user :content "Hello"}]
+                     :max-tokens 5}]
+    (try
+      (let [transformed (core/transform-request provider test-request)
+            response-future (core/make-request provider transformed thread-pools telemetry)
+            response @response-future
+            standard-response (core/transform-response provider response)]
+        {:success true
+         :provider "mistral"
+         :model "mistral-small-latest"
+         :response-id (:id standard-response)
+         :usage (:usage standard-response)})
+      (catch Exception e
+        {:success false
+         :provider "mistral"
+         :error (.getMessage e)
+         :error-type (type e)}))))
+
+;; Auto-register the provider when namespace is loaded
+(register-mistral-provider!)

--- a/test/litellm/providers/mistral_test.clj
+++ b/test/litellm/providers/mistral_test.clj
@@ -1,0 +1,193 @@
+(ns litellm.providers.mistral-test
+  (:require [clojure.test :refer :all]
+            [litellm.providers.mistral :as mistral]
+            [litellm.providers.core :as core]))
+
+(deftest test-transform-messages
+  (testing "Transform messages to Mistral format"
+    (let [messages [{:role :user :content "Hello"}
+                   {:role :assistant :content "Hi there"}
+                   {:role :user :content "How are you?"}]
+          result (mistral/transform-messages messages)]
+      (is (= 3 (count result)))
+      (is (= "user" (:role (first result))))
+      (is (= "Hello" (:content (first result))))
+      (is (= "assistant" (:role (second result)))))))
+
+(deftest test-add-reasoning-system-prompt
+  (testing "Add reasoning prompt to magistral models"
+    (let [messages [{:role "user" :content "What is 2+2?"}]
+          result (mistral/add-reasoning-system-prompt messages "medium")]
+      (is (= 2 (count result)))
+      (is (= "system" (:role (first result))))
+      (is (re-find #"think step-by-step" (:content (first result))))))
+  
+  (testing "Prepend reasoning prompt to existing system message"
+    (let [messages [{:role "system" :content "You are helpful"}
+                   {:role "user" :content "What is 2+2?"}]
+          result (mistral/add-reasoning-system-prompt messages "high")]
+      (is (= 2 (count result)))
+      (is (= "system" (:role (first result))))
+      (is (re-find #"think step-by-step" (:content (first result))))
+      (is (re-find #"You are helpful" (:content (first result)))))))
+
+(deftest test-supports-reasoning
+  (testing "Check if models support reasoning"
+    (is (mistral/supports-reasoning? "magistral-small-2506"))
+    (is (mistral/supports-reasoning? "magistral-medium-2506"))
+    (is (not (mistral/supports-reasoning? "mistral-small-latest")))
+    (is (not (mistral/supports-reasoning? "mistral-large-latest")))))
+
+(deftest test-transform-tools
+  (testing "Transform tools to Mistral format"
+    (let [tools [{:tool-type "function"
+                 :function {:name "get_weather"
+                           :description "Get the weather"
+                           :parameters {:type "object"}}}]
+          result (mistral/transform-tools tools)]
+      (is (= 1 (count result)))
+      (is (= "function" (:type (first result))))
+      (is (= "get_weather" (get-in (first result) [:function :name]))))))
+
+(deftest test-transform-tool-choice
+  (testing "Transform tool choice from keyword"
+    (is (= "auto" (mistral/transform-tool-choice :auto)))
+    (is (= "none" (mistral/transform-tool-choice :none))))
+  
+  (testing "Transform tool choice from map"
+    (let [choice {:type "function" :function {:name "get_weather"}}]
+      (is (= choice (mistral/transform-tool-choice choice))))))
+
+(deftest test-transform-usage
+  (testing "Transform usage to standard format"
+    (let [usage {:prompt_tokens 10 :completion_tokens 20 :total_tokens 30}
+          result (mistral/transform-usage usage)]
+      (is (= 10 (:prompt-tokens result)))
+      (is (= 20 (:completion-tokens result)))
+      (is (= 30 (:total-tokens result))))))
+
+(deftest test-transform-message
+  (testing "Transform message to standard format"
+    (let [message {:role "user" :content "Hello"}
+          result (mistral/transform-message message)]
+      (is (= :user (:role result)))
+      (is (= "Hello" (:content result)))))
+  
+  (testing "Transform message with tool calls"
+    (let [message {:role "assistant"
+                  :content nil
+                  :tool_calls [{:id "call_1"
+                               :type "function"
+                               :function {:name "get_weather"
+                                         :arguments "{\"location\":\"SF\"}"}}]}
+          result (mistral/transform-message message)]
+      (is (= :assistant (:role result)))
+      (is (= 1 (count (:tool-calls result))))
+      (is (= "call_1" (:id (first (:tool-calls result))))))))
+
+(deftest test-create-mistral-provider
+  (testing "Create Mistral provider with defaults"
+    (let [config {:api-key "test-key"}
+          provider (mistral/create-mistral-provider config)]
+      (is (= "test-key" (:api-key provider)))
+      (is (= "https://api.mistral.ai/v1" (:api-base provider)))
+      (is (= 30000 (:timeout provider)))
+      (is (map? (:cost-map provider)))
+      (is (map? (:rate-limits provider)))))
+  
+  (testing "Create Mistral provider with custom config"
+    (let [config {:api-key "test-key"
+                 :api-base "https://custom.api.com"
+                 :timeout 60000}
+          provider (mistral/create-mistral-provider config)]
+      (is (= "https://custom.api.com" (:api-base provider)))
+      (is (= 60000 (:timeout provider))))))
+
+(deftest test-provider-protocol
+  (testing "Provider implements protocol correctly"
+    (let [provider (mistral/create-mistral-provider {:api-key "test-key"})]
+      (is (= "mistral" (core/provider-name provider)))
+      (is (true? (core/supports-streaming? provider)))
+      (is (true? (core/supports-function-calling? provider)))
+      (is (map? (core/get-rate-limits provider)))
+      (is (map? (core/get-cost-per-token provider "mistral-small-latest"))))))
+
+(deftest test-transform-request
+  (testing "Transform basic request"
+    (let [provider (mistral/create-mistral-provider {:api-key "test-key"})
+          request {:model "mistral-small-latest"
+                  :messages [{:role :user :content "Hello"}]
+                  :max-tokens 100
+                  :temperature 0.7}
+          result (core/transform-request provider request)]
+      (is (= "mistral-small-latest" (:model result)))
+      (is (= 1 (count (:messages result))))
+      (is (= 100 (:max_tokens result)))
+      (is (= 0.7 (:temperature result)))))
+  
+  (testing "Transform request with reasoning effort"
+    (let [provider (mistral/create-mistral-provider {:api-key "test-key"})
+          request {:model "magistral-small-2506"
+                  :messages [{:role :user :content "Solve this"}]
+                  :reasoning-effort "medium"}
+          result (core/transform-request provider request)]
+      (is (= "magistral-small-2506" (:model result)))
+      ;; Should have added system message with reasoning prompt
+      (is (= "system" (:role (first (:messages result)))))
+      (is (re-find #"think step-by-step" (:content (first (:messages result)))))))
+  
+  (testing "Transform request with tools"
+    (let [provider (mistral/create-mistral-provider {:api-key "test-key"})
+          request {:model "mistral-large-latest"
+                  :messages [{:role :user :content "What's the weather?"}]
+                  :tools [{:tool-type "function"
+                          :function {:name "get_weather"
+                                    :description "Get weather"
+                                    :parameters {:type "object"}}}]
+                  :tool-choice :auto}
+          result (core/transform-request provider request)]
+      (is (= 1 (count (:tools result))))
+      (is (= "auto" (:tool_choice result))))))
+
+(deftest test-parse-sse-line
+  (testing "Parse valid SSE line"
+    (let [line "data: {\"id\":\"123\",\"choices\":[{\"delta\":{\"content\":\"Hello\"}}]}"
+          result (mistral/parse-sse-line line)]
+      (is (map? result))
+      (is (= "123" (:id result)))))
+  
+  (testing "Skip [DONE] marker"
+    (let [line "data: [DONE]"
+          result (mistral/parse-sse-line line)]
+      (is (nil? result))))
+  
+  (testing "Skip non-data lines"
+    (let [line ": comment"
+          result (mistral/parse-sse-line line)]
+      (is (nil? result)))))
+
+(deftest test-create-embedding-request
+  (testing "Create embedding request with string input"
+    (let [result (mistral/create-embedding-request "Hello world" nil)]
+      (is (= ["Hello world"] (:input result)))
+      (is (= "mistral-embed" (:model result)))))
+  
+  (testing "Create embedding request with vector input"
+    (let [result (mistral/create-embedding-request ["Hello" "World"] "mistral-embed")]
+      (is (= ["Hello" "World"] (:input result)))
+      (is (= "mistral-embed" (:model result))))))
+
+(deftest test-cost-map
+  (testing "Cost map contains expected models"
+    (is (contains? mistral/default-cost-map "mistral-small-latest"))
+    (is (contains? mistral/default-cost-map "mistral-large-latest"))
+    (is (contains? mistral/default-cost-map "magistral-small-2506"))
+    (is (contains? mistral/default-cost-map "mistral-embed"))
+    (is (contains? mistral/default-cost-map "codestral-latest")))
+  
+  (testing "Cost values are valid"
+    (let [cost (get mistral/default-cost-map "mistral-small-latest")]
+      (is (number? (:input cost)))
+      (is (number? (:output cost)))
+      (is (pos? (:input cost)))
+      (is (pos? (:output cost))))))


### PR DESCRIPTION
- Implement Mistral provider with full OpenAI-compatible API
- Support for all Mistral models (small, medium, large, codestral, magistral)
- Function calling support
- Streaming support
- Reasoning support for magistral models with reasoning_effort parameter
- Embedding support with mistral-embed model
- Comprehensive test suite
- Example usage file with 10 different use cases
- Updated README with Mistral configuration and examples