### PR TITLE
Add support for Azure OpenAI provider

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -45,4 +45,7 @@ jobs:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          AZURE_OPENAI_API_KEY: ${{ secrets.AZURE_OPENAI_API_KEY }}
+          AZURE_OPENAI_API_BASE: ${{ secrets.AZURE_OPENAI_API_BASE }}
+          AZURE_OPENAI_DEPLOYMENT: ${{ secrets.AZURE_OPENAI_DEPLOYMENT }}
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- **Azure OpenAI Support** - Full integration with Azure OpenAI Service
+  - Chat completions with deployment-based routing
+  - Streaming responses support
+  - Function calling / Tools support
+  - Embeddings support
+  - `setup-azure!` for quick configuration
+  - Environment variable support: `AZURE_OPENAI_API_KEY`, `AZURE_OPENAI_API_BASE`, `AZURE_OPENAI_DEPLOYMENT`
+  - Automatic setup via `quick-setup!` when Azure env vars are present
+
 ## [0.2.0] - 2025-05-10
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ LiteLLM Clojure provides a unified, idiomatic Clojure interface for interacting 
 |--------------|--------------|--------------------------------------------|------------------|-----------|
 | OpenAI       | ✅ Supported | GPT-5*, GPT-4*, GPT-3.5-Turbo | ✅               | ✅        |
 | Anthropic    | ✅ Supported | Claude 4.5 (Sonnet, Haiku), Claude 4.1 (Opus), Claude 3.7 | ✅               | ✅        |
+| Azure OpenAI | ✅ Supported | GPT-4, GPT-4o, GPT-3.5-Turbo (via deployments) | ✅               | ✅        |
 | OpenRouter   | ✅ Supported | All OpenRouter models                      | ✅               | ✅        |
 | Google Gemini| ✅ Supported | Gemini Pro, Gemini Pro Vision, Gemini Ultra| ❌               | ✅        |
 | Mistral      | ✅ Supported | Mistral Small/Medium/Large, Codestral, Magistral | ✅               | ✅        |
@@ -52,7 +53,7 @@ LiteLLM Clojure provides a unified, idiomatic Clojure interface for interacting 
 
 ### Planned Providers
 
-- Azure OpenAI
+- AWS Bedrock
 - Cohere
 - Hugging Face
 - Together AI

--- a/src/litellm/core.clj
+++ b/src/litellm/core.clj
@@ -9,6 +9,7 @@
             [litellm.providers.mistral]   ; Load to register provider
             [litellm.providers.ollama]    ; Load to register provider
             [litellm.providers.openrouter] ; Load to register provider
+            [litellm.providers.azure]     ; Load to register provider
             ))
 
 ;; ============================================================================

--- a/src/litellm/providers/azure.clj
+++ b/src/litellm/providers/azure.clj
@@ -1,0 +1,403 @@
+(ns litellm.providers.azure
+  "Azure OpenAI provider implementation for LiteLLM"
+  (:require [litellm.streaming :as streaming]
+            [litellm.errors :as errors]
+            [hato.client :as http]
+            [cheshire.core :as json]
+            [clojure.tools.logging :as log]
+            [clojure.core.async :as async :refer [go >!]]))
+
+;; ============================================================================
+;; Message Transformations (same as OpenAI)
+;; ============================================================================
+
+(defn transform-messages
+  "Transform messages to Azure OpenAI format (OpenAI-compatible)"
+  [messages]
+  (map (fn [msg]
+         (let [base {:role (name (:role msg))
+                     :content (:content msg)}]
+           (cond-> base
+             (:name msg) (assoc :name (:name msg))
+             (:tool-call-id msg) (assoc :tool_call_id (:tool-call-id msg)))))
+       messages))
+
+(defn transform-tools
+  "Transform tools to Azure OpenAI format (OpenAI-compatible)"
+  [tools]
+  (when tools
+    (map (fn [tool]
+           {:type (:tool-type tool "function")
+            :function (select-keys (:function tool) [:name :description :parameters])})
+         tools)))
+
+(defn transform-tool-choice
+  "Transform tool choice to Azure OpenAI format"
+  [tool-choice]
+  (cond
+    (keyword? tool-choice) (name tool-choice)
+    (map? tool-choice) tool-choice
+    :else tool-choice))
+
+;; ============================================================================
+;; Response Transformations (same as OpenAI)
+;; ============================================================================
+
+(defn transform-tool-calls
+  "Transform Azure OpenAI tool calls to standard format"
+  [tool-calls]
+  (when tool-calls
+    (map (fn [tool-call]
+           {:id (:id tool-call)
+            :type (:type tool-call)
+            :function {:name (get-in tool-call [:function :name])
+                       :arguments (get-in tool-call [:function :arguments])}})
+         tool-calls)))
+
+(defn transform-message
+  "Transform Azure OpenAI message to standard format"
+  [message]
+  (cond-> {:role (keyword (:role message))
+           :content (:content message)}
+    (:tool_calls message) (assoc :tool-calls (transform-tool-calls (:tool_calls message)))))
+
+(defn transform-choice
+  "Transform Azure OpenAI choice to standard format"
+  [choice]
+  {:index (:index choice)
+   :message (transform-message (:message choice))
+   :finish-reason (keyword (:finish_reason choice))})
+
+(defn transform-usage
+  "Transform Azure OpenAI usage to standard format"
+  [usage]
+  (when usage
+    {:prompt-tokens (:prompt_tokens usage)
+     :completion-tokens (:completion_tokens usage)
+     :total-tokens (:total_tokens usage)}))
+
+;; ============================================================================
+;; Error Handling
+;; ============================================================================
+
+(defn handle-error-response
+  "Handle Azure OpenAI API error responses"
+  [provider response]
+  (let [status (:status response)
+        body (:body response)
+        error-info (get body :error {})
+        message (or (:message error-info) "Unknown error")
+        provider-code (:code error-info)
+        request-id (get-in response [:headers "x-request-id"])]
+    (throw (errors/http-status->error
+            status
+            "azure"
+            message
+            :provider-code provider-code
+            :request-id request-id
+            :body body))))
+
+;; ============================================================================
+;; URL Building
+;; ============================================================================
+
+(defn build-chat-url
+  "Build the Azure OpenAI chat completions URL.
+
+  Config should contain:
+  - :api-base - Azure resource endpoint (e.g., https://my-resource.openai.azure.com)
+  - :deployment - Deployment name (e.g., gpt-4-deployment)
+  - :api-version - API version (default: 2024-10-21)"
+  [config]
+  (let [api-base (:api-base config)
+        deployment (:deployment config)
+        api-version (:api-version config "2024-10-21")]
+    (str api-base "/openai/deployments/" deployment "/chat/completions?api-version=" api-version)))
+
+(defn build-embedding-url
+  "Build the Azure OpenAI embeddings URL."
+  [config]
+  (let [api-base (:api-base config)
+        deployment (:deployment config)
+        api-version (:api-version config "2024-10-21")]
+    (str api-base "/openai/deployments/" deployment "/embeddings?api-version=" api-version)))
+
+;; ============================================================================
+;; Model and Cost Configuration
+;; ============================================================================
+
+(def default-cost-map
+  "Default cost per token for Azure OpenAI models (in USD)
+   Note: Azure pricing may vary by region and agreement"
+  {"gpt-4" {:input 0.00003 :output 0.00006}
+   "gpt-4-turbo" {:input 0.00001 :output 0.00003}
+   "gpt-4o" {:input 0.000005 :output 0.000015}
+   "gpt-4o-mini" {:input 0.00000015 :output 0.0000006}
+   "gpt-35-turbo" {:input 0.0000005 :output 0.0000015}
+   "gpt-35-turbo-16k" {:input 0.000003 :output 0.000004}})
+
+;; ============================================================================
+;; Azure OpenAI Provider Implementation Functions
+;; ============================================================================
+
+(defn transform-request-impl
+  "Azure OpenAI-specific transform-request implementation.
+  Note: model is not included in body as it's determined by deployment."
+  [provider-name request config]
+  (let [base {:messages (transform-messages (:messages request))}]
+
+    ;; Add optional parameters only if they are not nil
+    (cond-> base
+      (:max-tokens request) (assoc :max_tokens (:max-tokens request))
+      (:temperature request) (assoc :temperature (:temperature request))
+      (:top-p request) (assoc :top_p (:top-p request))
+      (:frequency-penalty request) (assoc :frequency_penalty (:frequency-penalty request))
+      (:presence-penalty request) (assoc :presence_penalty (:presence-penalty request))
+      (:stop request) (assoc :stop (:stop request))
+      (contains? request :stream) (assoc :stream (:stream request))
+      (:tools request) (assoc :tools (transform-tools (:tools request)))
+      (:tool-choice request) (assoc :tool_choice (transform-tool-choice (:tool-choice request))))))
+
+(defn make-request-impl
+  "Azure OpenAI-specific make-request implementation"
+  [provider-name transformed-request thread-pool telemetry config]
+  (let [url (build-chat-url config)]
+    (errors/wrap-http-errors
+     "azure"
+     #(let [start-time (System/currentTimeMillis)
+            response (http/post url
+                                (conj {:headers {"api-key" (:api-key config)
+                                                 "Content-Type" "application/json"
+                                                 "User-Agent" "litellm-clj/1.0.0"}
+                                       :body (json/encode transformed-request)
+                                       :timeout (:timeout config 30000)
+                                       :async? true
+                                       :as :json}
+                                      (when thread-pool
+                                        {:executor thread-pool})))
+            duration (- (System/currentTimeMillis) start-time)]
+
+         ;; Handle errors if response has error status
+        (when (>= (:status @response) 400)
+          (handle-error-response :azure @response))
+
+        response))))
+
+(defn transform-response-impl
+  "Azure OpenAI-specific transform-response implementation"
+  [provider-name response]
+  (let [body (:body response)]
+    {:id (:id body)
+     :object (:object body)
+     :created (:created body)
+     :model (:model body)
+     :choices (map transform-choice (:choices body))
+     :usage (transform-usage (:usage body))}))
+
+(defn supports-streaming-impl
+  "Azure OpenAI-specific supports-streaming? implementation"
+  [provider-name]
+  true)
+
+(defn supports-function-calling-impl
+  "Azure OpenAI-specific supports-function-calling? implementation"
+  [provider-name]
+  true)
+
+(defn get-rate-limits-impl
+  "Azure OpenAI-specific get-rate-limits implementation"
+  [provider-name]
+  {:requests-per-minute 1000
+   :tokens-per-minute 120000})
+
+(defn health-check-impl
+  "Azure OpenAI-specific health-check implementation"
+  [provider-name thread-pool config]
+  (try
+    ;; Azure doesn't have a simple /models endpoint like OpenAI
+    ;; We'll just try a minimal request to check connectivity
+    (let [url (build-chat-url config)
+          response (http/post url
+                              (conj {:headers {"api-key" (:api-key config)
+                                               "Content-Type" "application/json"}
+                                     :body (json/encode {:messages [{:role "user" :content "test"}]
+                                                         :max_tokens 1})
+                                     :timeout 5000
+                                     :as :json}
+                                    (when thread-pool
+                                      {:executor thread-pool})))]
+      (= 200 (:status response)))
+    (catch Exception e
+      (log/warn "Azure OpenAI health check failed" {:error (.getMessage e)})
+      false)))
+
+(defn get-cost-per-token-impl
+  "Azure OpenAI-specific get-cost-per-token implementation"
+  [provider-name model]
+  (get default-cost-map model {:input 0.0 :output 0.0}))
+
+;; ============================================================================
+;; Streaming Support
+;; ============================================================================
+
+(defn transform-streaming-chunk-impl
+  "Azure OpenAI-specific transform-streaming-chunk implementation"
+  [provider-name chunk]
+  (let [choice (first (:choices chunk))
+        delta (:delta choice)]
+    {:id (:id chunk)
+     :object (:object chunk)
+     :created (:created chunk)
+     :model (:model chunk)
+     :choices [{:index (:index choice)
+                :delta {:role (keyword (:role delta))
+                        :content (:content delta)}
+                :finish-reason (when (:finish_reason choice)
+                                 (keyword (:finish_reason choice)))}]}))
+
+(defn make-streaming-request-impl
+  "Azure OpenAI-specific make-streaming-request implementation"
+  [provider-name transformed-request thread-pool config]
+  (let [url (build-chat-url config)
+        output-ch (streaming/create-stream-channel)]
+    (go
+      (try
+        (let [response (http/post url
+                                  {:headers {"api-key" (:api-key config)
+                                             "Content-Type" "application/json"
+                                             "User-Agent" "litellm-clj/1.0.0"}
+                                   :body (json/encode transformed-request)
+                                   :timeout (:timeout config 30000)
+                                   :as :stream})]
+
+          ;; Handle errors
+          (when (>= (:status response) 400)
+            (>! output-ch (streaming/stream-error "azure"
+                                                  (str "HTTP " (:status response))
+                                                  :status (:status response)))
+            (streaming/close-stream! output-ch))
+
+          ;; Process streaming response
+          (when (= 200 (:status response))
+            (let [body (:body response)
+                  reader (java.io.BufferedReader.
+                          (java.io.InputStreamReader. body "UTF-8"))]
+              (loop []
+                (when-let [line (.readLine reader)]
+                  (when-let [parsed (streaming/parse-sse-line line json/decode)]
+                    (let [transformed (transform-streaming-chunk-impl :azure parsed)]
+                      (>! output-ch transformed)))
+                  (recur)))
+              (.close reader)
+              (streaming/close-stream! output-ch))))
+
+        (catch Exception e
+          (log/error "Error in streaming request" {:error (.getMessage e)})
+          (>! output-ch (streaming/stream-error "azure" (.getMessage e)))
+          (streaming/close-stream! output-ch))))
+
+    output-ch))
+
+;; ============================================================================
+;; Embedding Support
+;; ============================================================================
+
+(def default-embedding-cost-map
+  "Cost per token for Azure OpenAI embedding models (in USD)"
+  {"text-embedding-ada-002" {:input 0.0000001 :output 0.0}
+   "text-embedding-3-small" {:input 0.00000002 :output 0.0}
+   "text-embedding-3-large" {:input 0.00000013 :output 0.0}})
+
+(defn transform-embedding-request-impl
+  "Azure OpenAI-specific transform-embedding-request implementation"
+  [provider-name request config]
+  (let [input (:input request)
+        transformed {:input (if (string? input) [input] input)}]
+    (cond-> transformed
+      (:encoding-format request) (assoc :encoding_format (name (:encoding-format request)))
+      (:dimensions request) (assoc :dimensions (:dimensions request))
+      (:user request) (assoc :user (:user request)))))
+
+(defn make-embedding-request-impl
+  "Azure OpenAI-specific make-embedding-request implementation"
+  [provider-name transformed-request thread-pool telemetry config]
+  (let [url (build-embedding-url config)]
+    (errors/wrap-http-errors
+     "azure"
+     #(let [start-time (System/currentTimeMillis)
+            response (http/post url
+                                (conj {:headers {"api-key" (:api-key config)
+                                                 "Content-Type" "application/json"
+                                                 "User-Agent" "litellm-clj/1.0.0"}
+                                       :body (json/encode transformed-request)
+                                       :timeout (:timeout config 30000)
+                                       :async? true
+                                       :as :json}
+                                      (when thread-pool
+                                        {:executor thread-pool})))
+            duration (- (System/currentTimeMillis) start-time)]
+
+         ;; Handle errors if response has error status
+        (when (>= (:status @response) 400)
+          (handle-error-response :azure @response))
+
+        response))))
+
+(defn transform-embedding-response-impl
+  "Azure OpenAI-specific transform-embedding-response implementation"
+  [provider-name response]
+  (let [body (:body response)]
+    {:object (:object body)
+     :data (map (fn [item]
+                  {:object (:object item)
+                   :embedding (:embedding item)
+                   :index (:index item)})
+                (:data body))
+     :model (:model body)
+     :usage (transform-usage (:usage body))}))
+
+(defn supports-embeddings-impl
+  "Azure OpenAI-specific supports-embeddings? implementation"
+  [provider-name]
+  true)
+
+;; ============================================================================
+;; Utility Functions
+;; ============================================================================
+
+(defn validate-config
+  "Validate Azure OpenAI configuration"
+  [config]
+  (when-not (:api-base config)
+    (throw (ex-info "Azure OpenAI requires :api-base (e.g., https://my-resource.openai.azure.com)"
+                    {:config config})))
+  (when-not (:deployment config)
+    (throw (ex-info "Azure OpenAI requires :deployment (deployment name)"
+                    {:config config})))
+  (when-not (:api-key config)
+    (throw (ex-info "Azure OpenAI requires :api-key"
+                    {:config config})))
+  config)
+
+(defn test-azure-connection
+  "Test Azure OpenAI connection with a simple request"
+  [config thread-pool telemetry]
+  (let [validated-config (validate-config config)
+        test-request {:messages [{:role :user :content "Hello"}]
+                      :max-tokens 5}]
+    (try
+      (let [transformed (transform-request-impl :azure test-request validated-config)
+            response-future (make-request-impl :azure transformed thread-pool telemetry validated-config)
+            response @response-future
+            standard-response (transform-response-impl :azure response)]
+        {:success true
+         :provider "azure"
+         :deployment (:deployment validated-config)
+         :response-id (:id standard-response)
+         :usage (:usage standard-response)})
+      (catch Exception e
+        {:success false
+         :provider "azure"
+         :error (.getMessage e)
+         :error-type (type e)}))))
+

--- a/src/litellm/providers/core.clj
+++ b/src/litellm/providers/core.clj
@@ -9,7 +9,8 @@
             [litellm.providers.gemini :as gemini]
             [litellm.providers.mistral :as mistral]
             [litellm.providers.ollama :as ollama]
-            [litellm.providers.openrouter :as openrouter]))
+            [litellm.providers.openrouter :as openrouter]
+            [litellm.providers.azure :as azure]))
 
 ;; ============================================================================
 ;; Provider Multimethods and Implementations
@@ -40,6 +41,9 @@
 (defmethod transform-request :openrouter [provider-name request config]
   (openrouter/transform-request-impl provider-name request config))
 
+(defmethod transform-request :azure [provider-name request config]
+  (azure/transform-request-impl provider-name request config))
+
 ;; make-request
 ;; ----------------------------------------------------------------------------
 
@@ -65,6 +69,9 @@
 (defmethod make-request :openrouter [provider-name transformed-request thread-pool telemetry config]
   (openrouter/make-request-impl provider-name transformed-request thread-pool telemetry config))
 
+(defmethod make-request :azure [provider-name transformed-request thread-pool telemetry config]
+  (azure/make-request-impl provider-name transformed-request thread-pool telemetry config))
+
 ;; make-streaming-request
 ;; ----------------------------------------------------------------------------
 
@@ -83,6 +90,9 @@
 
 (defmethod make-streaming-request :openrouter [provider-name transformed-request thread-pool config]
   (openrouter/make-streaming-request-impl provider-name transformed-request thread-pool config))
+
+(defmethod make-streaming-request :azure [provider-name transformed-request thread-pool config]
+  (azure/make-streaming-request-impl provider-name transformed-request thread-pool config))
 
 ;; transform-response
 ;; ----------------------------------------------------------------------------
@@ -109,6 +119,9 @@
 (defmethod transform-response :openrouter [provider-name response]
   (openrouter/transform-response-impl provider-name response))
 
+(defmethod transform-response :azure [provider-name response]
+  (azure/transform-response-impl provider-name response))
+
 ;; transform-streaming-chunk
 ;; ----------------------------------------------------------------------------
 
@@ -127,6 +140,9 @@
 
 (defmethod transform-streaming-chunk :openrouter [provider-name chunk]
   (openrouter/transform-streaming-chunk-impl provider-name chunk))
+
+(defmethod transform-streaming-chunk :azure [provider-name chunk]
+  (azure/transform-streaming-chunk-impl provider-name chunk))
 
 ;; supports-streaming?
 ;; ----------------------------------------------------------------------------
@@ -155,6 +171,9 @@
 (defmethod supports-streaming? :openrouter [provider-name]
   (openrouter/supports-streaming-impl provider-name))
 
+(defmethod supports-streaming? :azure [provider-name]
+  (azure/supports-streaming-impl provider-name))
+
 ;; supports-function-calling?
 ;; ----------------------------------------------------------------------------
 
@@ -181,6 +200,9 @@
 
 (defmethod supports-function-calling? :openrouter [provider-name]
   (openrouter/supports-function-calling-impl provider-name))
+
+(defmethod supports-function-calling? :azure [provider-name]
+  (azure/supports-function-calling-impl provider-name))
 
 ;; get-rate-limits
 ;; ----------------------------------------------------------------------------
@@ -211,6 +233,9 @@
 (defmethod get-rate-limits :openrouter [provider-name]
   (openrouter/get-rate-limits-impl provider-name))
 
+(defmethod get-rate-limits :azure [provider-name]
+  (azure/get-rate-limits-impl provider-name))
+
 ;; health-check
 ;; ----------------------------------------------------------------------------
 
@@ -235,6 +260,9 @@
 
 (defmethod health-check :openrouter [provider-name thread-pool config]
   (openrouter/health-check-impl provider-name thread-pool config))
+
+(defmethod health-check :azure [provider-name thread-pool config]
+  (azure/health-check-impl provider-name thread-pool config))
 
 ;; get-cost-per-token
 ;; ----------------------------------------------------------------------------
@@ -264,6 +292,9 @@
 (defmethod get-cost-per-token :openrouter [provider-name model]
   (openrouter/get-cost-per-token-impl provider-name model))
 
+(defmethod get-cost-per-token :azure [provider-name model]
+  (azure/get-cost-per-token-impl provider-name model))
+
 ;; transform-embedding-request
 ;; ----------------------------------------------------------------------------
 
@@ -279,6 +310,9 @@
 
 (defmethod transform-embedding-request :gemini [provider-name request config]
   (gemini/transform-embedding-request-impl provider-name request config))
+
+(defmethod transform-embedding-request :azure [provider-name request config]
+  (azure/transform-embedding-request-impl provider-name request config))
 
 ;; make-embedding-request
 ;; ----------------------------------------------------------------------------
@@ -296,6 +330,9 @@
 (defmethod make-embedding-request :gemini [provider-name transformed-request thread-pool telemetry config]
   (gemini/make-embedding-request-impl provider-name transformed-request thread-pool telemetry config))
 
+(defmethod make-embedding-request :azure [provider-name transformed-request thread-pool telemetry config]
+  (azure/make-embedding-request-impl provider-name transformed-request thread-pool telemetry config))
+
 ;; transform-embedding-response
 ;; ----------------------------------------------------------------------------
 
@@ -311,6 +348,9 @@
 
 (defmethod transform-embedding-response :gemini [provider-name response]
   (gemini/transform-embedding-response-impl provider-name response))
+
+(defmethod transform-embedding-response :azure [provider-name response]
+  (azure/transform-embedding-response-impl provider-name response))
 
 ;; supports-embeddings?
 ;; ----------------------------------------------------------------------------
@@ -329,6 +369,9 @@
 
 (defmethod supports-embeddings? :gemini [provider-name]
   (gemini/supports-embeddings-impl provider-name))
+
+(defmethod supports-embeddings? :azure [provider-name]
+  (azure/supports-embeddings-impl provider-name))
 
 ;; ============================================================================
 ;; Provider Validation

--- a/test/litellm/providers/azure_test.clj
+++ b/test/litellm/providers/azure_test.clj
@@ -1,0 +1,233 @@
+(ns litellm.providers.azure-test
+  (:require [clojure.test :refer [deftest testing is]]
+            [litellm.providers.azure :as azure]))
+
+;; ============================================================================
+;; Message Transformation Tests
+;; ============================================================================
+
+(deftest test-transform-messages
+  (testing "Transform messages to Azure OpenAI format"
+    (let [messages [{:role :user :content "Hello"}
+                   {:role :assistant :content "Hi there"}]
+          transformed (azure/transform-messages messages)]
+      (is (= 2 (count transformed)))
+      (is (= "user" (:role (first transformed))))
+      (is (= "Hello" (:content (first transformed)))))))
+
+(deftest test-transform-tools
+  (testing "Transform tools to Azure OpenAI format"
+    (let [tools [{:function {:name "get_weather"
+                            :description "Get weather"}}]
+          transformed (azure/transform-tools tools)]
+      (is (= 1 (count transformed)))
+      (is (= "get_weather" (get-in (first transformed) [:function :name]))))))
+
+(deftest test-transform-message
+  (testing "Transform Azure OpenAI message to standard format"
+    (let [message {:role "assistant" :content "Hello"}
+          transformed (azure/transform-message message)]
+      (is (= :assistant (:role transformed)))
+      (is (= "Hello" (:content transformed))))))
+
+(deftest test-transform-usage
+  (testing "Transform usage information"
+    (let [usage {:prompt_tokens 10
+                :completion_tokens 20
+                :total_tokens 30}
+          transformed (azure/transform-usage usage)]
+      (is (= 10 (:prompt-tokens transformed)))
+      (is (= 20 (:completion-tokens transformed)))
+      (is (= 30 (:total-tokens transformed))))))
+
+;; ============================================================================
+;; URL Building Tests
+;; ============================================================================
+
+(deftest test-build-chat-url
+  (testing "Build chat completions URL with default API version"
+    (let [config {:api-base "https://my-resource.openai.azure.com"
+                 :deployment "gpt-4-deployment"}
+          url (azure/build-chat-url config)]
+      (is (= "https://my-resource.openai.azure.com/openai/deployments/gpt-4-deployment/chat/completions?api-version=2024-10-21" url))))
+
+  (testing "Build chat completions URL with custom API version"
+    (let [config {:api-base "https://my-resource.openai.azure.com"
+                 :deployment "gpt-4-deployment"
+                 :api-version "2024-06-01"}
+          url (azure/build-chat-url config)]
+      (is (= "https://my-resource.openai.azure.com/openai/deployments/gpt-4-deployment/chat/completions?api-version=2024-06-01" url)))))
+
+(deftest test-build-embedding-url
+  (testing "Build embeddings URL"
+    (let [config {:api-base "https://my-resource.openai.azure.com"
+                 :deployment "embedding-deployment"}
+          url (azure/build-embedding-url config)]
+      (is (= "https://my-resource.openai.azure.com/openai/deployments/embedding-deployment/embeddings?api-version=2024-10-21" url)))))
+
+;; ============================================================================
+;; Request Transformation Tests
+;; ============================================================================
+
+(deftest test-transform-request-basic
+  (testing "Transform basic request - model not in body for Azure"
+    (let [request {:model "gpt-4"
+                  :messages [{:role :user :content "Hello"}]
+                  :max-tokens 100}
+          config {}
+          transformed (azure/transform-request-impl :azure request config)]
+      ;; Azure doesn't include model in body - it's determined by deployment
+      (is (not (contains? transformed :model)))
+      (is (= 100 (:max_tokens transformed)))
+      (is (= 1 (count (:messages transformed)))))))
+
+(deftest test-transform-request-with-all-params
+  (testing "Transform request with all optional parameters"
+    (let [request {:model "gpt-4"
+                  :messages [{:role :user :content "Hello"}]
+                  :max-tokens 100
+                  :temperature 0.7
+                  :top-p 0.9
+                  :frequency-penalty 0.5
+                  :presence-penalty 0.5
+                  :stop ["END"]}
+          config {}
+          transformed (azure/transform-request-impl :azure request config)]
+      (is (= 100 (:max_tokens transformed)))
+      (is (= 0.7 (:temperature transformed)))
+      (is (= 0.9 (:top_p transformed)))
+      (is (= 0.5 (:frequency_penalty transformed)))
+      (is (= 0.5 (:presence_penalty transformed)))
+      (is (= ["END"] (:stop transformed))))))
+
+;; ============================================================================
+;; Capability Tests
+;; ============================================================================
+
+(deftest test-supports-streaming
+  (testing "Azure OpenAI supports streaming"
+    (is (true? (azure/supports-streaming-impl :azure)))))
+
+(deftest test-supports-function-calling
+  (testing "Azure OpenAI supports function calling"
+    (is (true? (azure/supports-function-calling-impl :azure)))))
+
+(deftest test-supports-embeddings
+  (testing "Azure OpenAI supports embeddings"
+    (is (true? (azure/supports-embeddings-impl :azure)))))
+
+;; ============================================================================
+;; Error Handling Tests
+;; ============================================================================
+
+(deftest test-handle-error-response-401
+  (testing "Handle 401 authentication error"
+    (let [response {:status 401 :body {:error {:message "Invalid API key"}}}]
+      (is (thrown-with-msg? Exception #"Invalid API key"
+                            (azure/handle-error-response :azure response))))))
+
+(deftest test-handle-error-response-429
+  (testing "Handle 429 rate limit error"
+    (let [response {:status 429
+                   :body {:error {:message "Rate limit exceeded"}}
+                   :headers {"retry-after" "60"}}]
+      (is (thrown-with-msg? Exception #"Rate limit exceeded"
+                            (azure/handle-error-response :azure response))))))
+
+;; ============================================================================
+;; Cost Tests
+;; ============================================================================
+
+(deftest test-get-cost-per-token
+  (testing "Get cost for known model"
+    (let [cost (azure/get-cost-per-token-impl :azure "gpt-4")]
+      (is (some? cost))
+      (is (contains? cost :input))
+      (is (contains? cost :output))))
+
+  (testing "Get cost for unknown model returns zeros"
+    (let [cost (azure/get-cost-per-token-impl :azure "unknown-model")]
+      (is (= {:input 0.0 :output 0.0} cost)))))
+
+;; ============================================================================
+;; Embedding Tests
+;; ============================================================================
+
+(deftest test-transform-embedding-request-single-input
+  (testing "Transform embedding request with single string input"
+    (let [request {:model "text-embedding-ada-002"
+                  :input "Hello world"}
+          config {}
+          transformed (azure/transform-embedding-request-impl :azure request config)]
+      (is (vector? (:input transformed)))
+      (is (= 1 (count (:input transformed))))
+      (is (= "Hello world" (first (:input transformed)))))))
+
+(deftest test-transform-embedding-request-array-input
+  (testing "Transform embedding request with array input"
+    (let [request {:model "text-embedding-ada-002"
+                  :input ["Hello" "World"]}
+          config {}
+          transformed (azure/transform-embedding-request-impl :azure request config)]
+      (is (vector? (:input transformed)))
+      (is (= 2 (count (:input transformed))))
+      (is (= "Hello" (first (:input transformed))))
+      (is (= "World" (second (:input transformed)))))))
+
+(deftest test-transform-embedding-response
+  (testing "Transform embedding response from Azure OpenAI format"
+    (let [response {:body {:object "list"
+                          :data [{:object "embedding"
+                                 :embedding [0.1 0.2 0.3]
+                                 :index 0}
+                                {:object "embedding"
+                                 :embedding [0.4 0.5 0.6]
+                                 :index 1}]
+                          :model "text-embedding-ada-002"
+                          :usage {:prompt_tokens 10
+                                 :completion_tokens 0
+                                 :total_tokens 10}}}
+          transformed (azure/transform-embedding-response-impl :azure response)]
+      (is (= "list" (:object transformed)))
+      (is (= "text-embedding-ada-002" (:model transformed)))
+      (is (= 2 (count (:data transformed))))
+      (is (= [0.1 0.2 0.3] (:embedding (first (:data transformed)))))
+      (is (= [0.4 0.5 0.6] (:embedding (second (:data transformed)))))
+      (is (= 10 (get-in transformed [:usage :prompt-tokens])))
+      (is (= 0 (get-in transformed [:usage :completion-tokens]))))))
+
+(deftest test-embedding-cost-map
+  (testing "Embedding cost map contains known models"
+    (is (contains? azure/default-embedding-cost-map "text-embedding-ada-002"))
+    (is (contains? azure/default-embedding-cost-map "text-embedding-3-small"))
+    (is (contains? azure/default-embedding-cost-map "text-embedding-3-large"))
+
+    (testing "Costs have correct structure"
+      (let [cost (get azure/default-embedding-cost-map "text-embedding-ada-002")]
+        (is (contains? cost :input))
+        (is (contains? cost :output))
+        (is (number? (:input cost)))
+        (is (zero? (:output cost)))))))
+
+;; ============================================================================
+;; Config Validation Tests
+;; ============================================================================
+
+(deftest test-validate-config
+  (testing "Valid config passes validation"
+    (let [config {:api-base "https://my-resource.openai.azure.com"
+                 :deployment "gpt-4"
+                 :api-key "test-key"}]
+      (is (= config (azure/validate-config config)))))
+
+  (testing "Missing api-base throws"
+    (let [config {:deployment "gpt-4" :api-key "test-key"}]
+      (is (thrown? Exception (azure/validate-config config)))))
+
+  (testing "Missing deployment throws"
+    (let [config {:api-base "https://my-resource.openai.azure.com" :api-key "test-key"}]
+      (is (thrown? Exception (azure/validate-config config)))))
+
+  (testing "Missing api-key throws"
+    (let [config {:api-base "https://my-resource.openai.azure.com" :deployment "gpt-4"}]
+      (is (thrown? Exception (azure/validate-config config))))))


### PR DESCRIPTION
### Added
- **Azure OpenAI Support** 
  - Full integration with Azure OpenAI Service
  - Chat completions with deployment-based routing
  - Streaming responses support
  - Function calling / Tools support
  - Embeddings support
  - `setup-azure!` for quick configuration
  - Environment variable support: `AZURE_OPENAI_API_KEY`, `AZURE_OPENAI_API_BASE`, `AZURE_OPENAI_DEPLOYMENT`
  - Automatic setup via `quick-setup!` when Azure env vars are present